### PR TITLE
Fix for regions requiring redirect (e.g us-west-2)

### DIFF
--- a/src/S3Client.js
+++ b/src/S3Client.js
@@ -16,7 +16,7 @@ class S3Client {
         if (config.region.split('-')[0] === 'cn') {
             url = `https://${config.bucketName}.s3.${config.region}.amazonaws.com.cn`;
         } else {
-            url = `https://${config.bucketName}.s3.amazonaws.com`;
+            url = `https://${config.bucketName}.s3-${config.region}.amazonaws.com`;
         }
         fd.append("key", key);
         fd.append("acl", "public-read");


### PR DESCRIPTION
When using S3 from a us-west-2 server replies with Redirect 307 with body
```
<Error><Code>TemporaryRedirect</Code><Message>Please re-send this request to the specified temporary endpoint. Continue to use the original request endpoint for future requests.</Message><Endpoint>bucket-name.s3-us-west-2.amazonaws.com</Endpoint>...
```

Which is not properly handled by fetch (maybe correct fix would be to make fetch do redirects). 

This fix is pointing to the proper URL considering region.