### PR TITLE
Resolve deleteFile issue where missing region in url causes error

### DIFF
--- a/src/S3Client.ts
+++ b/src/S3Client.ts
@@ -48,7 +48,7 @@ class S3Client {
     }
     public async deleteFile(fileName: string): Promise<DeleteResponse> {
       const url: string = `https://${this.config.bucketName}.s3${
-        this.config.region ? "-" + config.region : ""
+        this.config.region ? "-" + this.config.region : ""
         }.amazonaws.com/${
         this.config.dirName ? this.config.dirName + "/" : ""
         }${fileName}`;

--- a/src/S3Client.ts
+++ b/src/S3Client.ts
@@ -47,8 +47,8 @@ class S3Client {
       });
     }
     public async deleteFile(fileName: string): Promise<DeleteResponse> {
-      const url: string = `https://${this.config.bucketName}.s3-${
-        this.config.region
+      const url: string = `https://${this.config.bucketName}.s3${
+        this.config.region ? "-" + config.region : ""
         }.amazonaws.com/${
         this.config.dirName ? this.config.dirName + "/" : ""
         }${fileName}`;


### PR DESCRIPTION
Resolves issue #15.

A region is not always needed to write to a S3 storage bucket. It should not be a required parameter.