### PR TITLE
Fixing issue: #45 Invalid URL in region us-east-1

### DIFF
--- a/src/Url.ts
+++ b/src/Url.ts
@@ -1,9 +1,10 @@
 
 export default (countryCode: string, bucketName: string, region: string): string => {
-  switch(countryCode) {
-    case "cn":
-      return `https://${bucketName}.s3.${region}.amazonaws.com.${countryCode}`;
-    default:
-      return `https://${bucketName}.s3-${region}.amazonaws.com`;
+  if(countryCode === "cn"){
+     return `https://${bucketName}.s3.${region}.amazonaws.com.${countryCode}`;
+  }else if(region === "us-east-1"){
+     return `https://${bucketName}.s3.${region}.amazonaws.com`;
+  }else{
+    return `https://${bucketName}.s3-${region}.amazonaws.com`;
   }
 }


### PR DESCRIPTION
Fixing issue: https://github.com/Fausto95/aws-s3/issues/45
When the region is `us-east-1` the URL should be built in another way than the other regions (regions in China do not apply this rule)